### PR TITLE
Add support of generic binary data type

### DIFF
--- a/src/Barberry/ContentType.php
+++ b/src/Barberry/ContentType.php
@@ -29,6 +29,7 @@ use finfo;
  * @method string ico($mime = '') static
  * @method string css($mime = '') static
  * @method string html($mime = '') static
+ * @method string dat($mime = '') static
  *
  * @package Barberry
  */
@@ -74,7 +75,8 @@ class ContentType
         'ico' => array('image/x-icon', 'image/vnd.microsoft.icon'),
         'css' => 'text/css',
         'html' => 'text/html',
-        'nws' => 'message/news'
+        'nws' => 'message/news',
+        'dat' => 'application/octet-stream'
     );
 
     private $contentTypeString;

--- a/test/ContentTypeTest.php
+++ b/test/ContentTypeTest.php
@@ -52,4 +52,9 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase {
             ContentType::byString("Article_Number\tPrice\n1000.1\t99.90")->standardExtension()
         );
     }
+
+    public function testGenericBinaryDataContentTypeIsPossible()
+    {
+        $this->assertSame('application/octet-stream', (string) ContentType::dat('application/octet-stream'));
+    }
 }


### PR DESCRIPTION
@Magomogo we upload to barberry files which are considered as `application/octet-stream`, let's add support of such generic binary data files.