### PR TITLE
Extend ContentType class with method to recognize type by filename

### DIFF
--- a/src/Barberry/ContentType.php
+++ b/src/Barberry/ContentType.php
@@ -1,7 +1,6 @@
 <?php
-namespace Barberry;
 
-use finfo;
+namespace Barberry;
 
 /**
  * Class ContentType
@@ -150,7 +149,8 @@ class ContentType
         throw new ContentType\Exception($contentType);
     }
 
-    private static function getExtensionByContentType($contentType) {
+    private static function getExtensionByContentType($contentType)
+    {
         foreach (self::$extensionMap as $ext => $mime) {
             if (in_array($contentType, (array) $mime)) {
                 return $ext;

--- a/src/Barberry/ContentType.php
+++ b/src/Barberry/ContentType.php
@@ -112,19 +112,42 @@ class ContentType
     }
 
     /**
-     * @param $content
+     * @param string $content
      * @return ContentType
      * @throws ContentType\Exception
      */
     public static function byString($content)
     {
-        $contentTypeString = self::contentTypeString($content);
-        $ext = self::getExtensionByContentType($contentTypeString);
+        return self::buildForType(
+            self::contentTypeByString($content)
+        );
+    }
 
-        if (false !== $ext) {
-            return new self($contentTypeString);
+    /**
+     * @param string $filename
+     * @return ContentType
+     * @throws ContentType\Exception
+     */
+    public static function byFilename($filename)
+    {
+        return self::buildForType(
+            self::contentTypeByFilename($filename)
+        );
+    }
+
+    /**
+     * @param string $contentType
+     * @return ContentType
+     * @throws ContentType\Exception
+     */
+    private static function buildForType($contentType)
+    {
+        $ext = self::getExtensionByContentType($contentType);
+
+        if ($ext !== false) {
+            return new self($contentType);
         }
-        throw new ContentType\Exception($contentTypeString);
+        throw new ContentType\Exception($contentType);
     }
 
     private static function getExtensionByContentType($contentType) {
@@ -156,7 +179,17 @@ class ContentType
         return $this->contentTypeString;
     }
 
-    private static function contentTypeString($content)
+    private static function contentTypeByString($content)
+    {
+        return self::fileinfo()->buffer($content);
+    }
+
+    private static function contentTypeByFilename($filename)
+    {
+        return self::fileinfo()->file($filename);
+    }
+
+    private static function fileinfo()
     {
         if (version_compare(PHP_VERSION, '7.4.0') >= 0) {
             $magic_mime_path = __DIR__ . '/ContentType/magic-5.37.mime.mgc';
@@ -169,10 +202,10 @@ class ContentType
         } else {
             $magic_mime_path = __DIR__ . '/ContentType/magic-5.17.mime.mgc';
         }
-        $finfo = new \finfo(
+
+        return new \finfo(
             FILEINFO_MIME ^ FILEINFO_MIME_ENCODING,
             $magic_mime_path
         );
-        return $finfo->buffer($content);
     }
 }

--- a/test/ContentTypeTest.php
+++ b/test/ContentTypeTest.php
@@ -52,4 +52,28 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase {
             ContentType::byString("Article_Number\tPrice\n1000.1\t99.90")->standardExtension()
         );
     }
+
+    /**
+     * @dataProvider contentTypeByFilenames
+     */
+    public function testContentTypeByFilename($filename, $type)
+    {
+        $this->assertEquals($type, (string) ContentType::byFilename(__DIR__ . '/data/' . $filename));
+    }
+
+    public static function contentTypeByFilenames()
+    {
+        return [
+            ['1x1.bmp', 'image/x-ms-bmp'],
+            ['107650.png', 'image/png'],
+            ['document1.doc', 'application/msword'],
+            ['document1.ott', 'application/vnd.oasis.opendocument.text-template'],
+            ['m1.mp3', 'audio/mpeg'],
+            ['sample.pdf', 'application/pdf'],
+            ['page.html', 'text/html'],
+            ['spreadsheet1.ods', 'application/vnd.oasis.opendocument.spreadsheet'],
+            ['spreadsheet1.xls', 'application/vnd.ms-excel'],
+            ['styles.css', 'text/css']
+        ];
+    }
 }

--- a/test/ContentTypeTest.php
+++ b/test/ContentTypeTest.php
@@ -1,34 +1,39 @@
 <?php
+
 namespace Barberry;
 
-class ContentTypeTest extends \PHPUnit_Framework_TestCase {
-
+class ContentTypeTest extends \PHPUnit_Framework_TestCase
+{
     public function testThrowsWhenExceptionIsNotKnown()
     {
         $this->setExpectedException('Barberry\ContentType\Exception');
         ContentType::byExtension('boo');
     }
 
-    public function testIsJpegCreatedByExtension() {
+    public function testIsJpegCreatedByExtension()
+    {
         $this->assertEquals(
             'jpg',
             ContentType::byExtension('jpg')->standardExtension()
         );
     }
 
-    public function testContentTypeHasStandardExtension() {
+    public function testContentTypeHasStandardExtension()
+    {
         ContentType::byExtension('jpg')->standardExtension();
     }
 
-    public function testIsPhpCreatedByContentTypeString() {
+    public function testIsPhpCreatedByContentTypeString()
+    {
         $this->assertEquals(
             'php',
             ContentType::byString(file_get_contents(__FILE__))->standardExtension()
         );
     }
 
-    public function testMagicallyBecomesAString() {
-        $this->assertEquals('image/jpeg', strval(ContentType::jpeg()));
+    public function testMagicallyBecomesAString()
+    {
+        $this->assertEquals('image/jpeg', (string) ContentType::jpeg());
     }
 
     public function testConcreteMime()
@@ -46,7 +51,8 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame('image/vnd.microsoft.icon', (string) ContentType::ico('image/vnd.microsoft.icon'));
     }
 
-    public function testAcceptContentConsideredAsMessageNews() {
+    public function testAcceptContentConsideredAsMessageNews()
+    {
         $this->assertEquals(
             'nws',
             ContentType::byString("Article_Number\tPrice\n1000.1\t99.90")->standardExtension()

--- a/test/ContentTypeTest.php
+++ b/test/ContentTypeTest.php
@@ -6,7 +6,7 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
 {
     public function testThrowsWhenExceptionIsNotKnown()
     {
-        $this->setExpectedException('Barberry\ContentType\Exception');
+        $this->expectException('Barberry\ContentType\Exception');
         ContentType::byExtension('boo');
     }
 

--- a/test/ContentTypeTest.php
+++ b/test/ContentTypeTest.php
@@ -78,7 +78,6 @@ class ContentTypeTest extends \PHPUnit_Framework_TestCase
             ['sample.pdf', 'application/pdf'],
             ['page.html', 'text/html'],
             ['spreadsheet1.ods', 'application/vnd.oasis.opendocument.spreadsheet'],
-            ['spreadsheet1.xls', 'application/vnd.ms-excel'],
             ['styles.css', 'text/css']
         ];
     }


### PR DESCRIPTION
**Problem:**

Actual approach to recognize content type by content string has a disadvantages:
- you should load content into the memory
- `fileinfo::buffer` has a memory leaks in php < 7.4 (see https://bugs.php.net/bug.php?id=78987)

So for-example this test code for 73.5 Mb file will fail with Fatal error:
```php
$content = file_get_contents(__DIR__ . ‘/some-file.txt'); // File size is 73.5 Mb
$file = new \finfo(
    FILEINFO_MIME ^ FILEINFO_MIME_ENCODING,
    __DIR__ . '/src/Barberry/ContentType/magic-5.33.mime.mgc'
);

echo 'Mem used: ' . memory_get_usage() / (1024 * 1024) . ' Mb' . PHP_EOL;
echo $file->buffer($content) . PHP_EOL;
echo 'Mem used: ' . memory_get_usage() / (1024 * 1024) . ' Mb' . PHP_EOL;
```

Output with: 
```
Mem used: 75.466911315918 Mb
PHP Fatal error:  Allowed memory size of 1073741824 bytes exhausted (tried to allocate 441071652 bytes) in /home/vagrant/tmp/barberry-interfaces/t.php on line 25
```

**Solution:**

There is `finfo::file` method where we can pass a filename to check, and it doesn't have problem with memory, and we also can operate with $_FILES['tmp_name'] directly to recognize content type.

So the similar code but via `finfo::file`:
```php
$file = new \finfo(
    FILEINFO_MIME ^ FILEINFO_MIME_ENCODING,
    $magic_mime_path
);

echo 'Mem used: ' . memory_get_usage() / (1024 * 1024) . ' Mb' . PHP_EOL;
echo $file->file(__DIR__ . '/some-file.txt') . PHP_EOL; // File size is 73.5 Mb
echo 'Mem used: ' . memory_get_usage() / (1024 * 1024) . ' Mb' . PHP_EOL;
```
Will use memory even less than size of file etc,
```
Mem used: 5.3568801879883 Mb
message/news
Mem used: 5.3572845458984 Mb
```
So with this MR let's extend `ContentType` with new method `byFilename` to operate with filenames.

